### PR TITLE
docs(배포가이드): 존재하지 않는 run-local.sh 참조 제거

### DIFF
--- a/docs/08_deployment.md
+++ b/docs/08_deployment.md
@@ -32,11 +32,6 @@ cd byeolnight
 # 2. 환경변수 설정
 cp .env.example .env
 # .env 파일을 열어서 실제 값들로 수정
-
-# 3. 로컬 개발 환경 실행 (권장)
-./run-local.bat  # Windows
-# 또는
-chmod +x run-local.sh && ./run-local.sh  # Linux/Mac
 ```
 
 ### 3. 환경변수 설정 (.env 파일)

--- a/docs/10_contributing.md
+++ b/docs/10_contributing.md
@@ -30,11 +30,6 @@ git remote add upstream https://github.com/original-owner/byeolnight.git
 # 3. 개발 환경 설정
 cp .env.example .env
 # .env 파일을 개발용 설정으로 수정
-
-# 4. 로컬 환경 실행
-./run-local.bat  # Windows
-# 또는
-./run-local.sh   # Linux/Mac
 ```
 
 ### 2. 브랜치 전략


### PR DESCRIPTION
배포 가이드 문서에 Linux/Mac 환경을 위한 `./run-local.sh` 실행 명령어가 포함되어 있었으나, 실제 프로젝트에는 해당 스크립트 파일이 존재하지 않았습니다.

- 08_deployment.md
- 10_contributing.md